### PR TITLE
feat: add a field `skip_push`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ GitHub Actions to format code and push commit
 This action executes the given command to format code.
 If code isn't changed, this means code is originally formatted, so the action succeeds.
 If code is changed, this means code isn't originally formatted, so the action fails.
-If code is changed and the action event is either `pull_request` or `pull_request_target`, this action commits the change and pushes the commit to the remote branch.
+If code is changed and the input `skip_push` is `false`, this action commits the change and pushes the commit to the remote branch.
 
 ## Requirements
 
-* [ghcp](https://github.com/int128/ghcp)
+- [ghcp](https://github.com/int128/ghcp)
 
 ## License
 

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,10 @@ inputs:
     description: working directory
     required: false
     default: ""
+  skip_push:
+    required: false
+    description: If "true", this action skips pushing a commit
+    default: false
 runs:
   using: composite
   steps:
@@ -23,6 +27,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        SKIP_PUSH: ${{ inputs.skip_push }}
         ROOT_DIR: ${{ github.workspace }}
         INPUT_COMMAND: ${{ inputs.command }}
         INPUT_COMMIT_MESSAGE: ${{ inputs.commit_message }}

--- a/main.sh
+++ b/main.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
-set -o pipefail
+set -euo pipefail
 
 tempfile=$(mktemp)
 eval "$INPUT_COMMAND" >"$tempfile"
@@ -12,8 +11,7 @@ fi
 
 echo "::error Files aren't formatted"
 
-# Check if EVENT_NAME is either pull_request or pull_request_target
-if [ "$EVENT_NAME" != "pull_request" ] && [ "$EVENT_NAME" != "pull_request_target" ]; then
+if [ "$SKIP_PUSH" = true ]; then
 	rm "$tempfile"
 	exit 1
 fi


### PR DESCRIPTION
BREAKING CHANGE: This action pushes commits even if the event isn't pull_request or pull_request_target.

If you want to skip pusing commits, you need to specify the field `skip_push`.